### PR TITLE
Update build_consensus_reference.py to prevent the AssertionError

### DIFF
--- a/src/starcat/build_consensus_reference.py
+++ b/src/starcat/build_consensus_reference.py
@@ -297,8 +297,9 @@ class BuildConsensusReference():
                 clus_dict_all[gep_num] = [gep]     
         
         # Relabel GEPs and order by cNMF result source
+        max_clus_size = max(len(v) for v in clus_dict_all.values())
         clus_df = pd.DataFrame.from_dict(clus_dict_all, orient='index', 
-                                         columns = ['GEP%d' % x for x in range(1, self.num_results+1)])
+                                         columns = ['GEP%d' % x for x in range(1, max_clus_size+1)])
         result_names = sorted(clus_df.unstack().dropna().apply(lambda x: x.split(':')[0]).unique())
         
         clus_df_clean = pd.DataFrame(index=clus_df.index, columns=result_names)


### PR DESCRIPTION
When the largest identified cluster in `clus_dict_all` is smaller than the total number of individual cNMF results (`self.num_results`), `pd.DataFrame.from_dict` causes the assertion error, e.g.
 
<pre>
Traceback (most recent call last):
  File “/home/unix/safina/.conda/envs/cnmf/lib/python3.10/site-packages/pandas/core/internals/construction.py”, line 939, in _finalize_columns_and_data
    columns = _validate_or_indexify_columns(contents, columns)
  File “/home/unix/safina/.conda/envs/cnmf/lib/python3.10/site-packages/pandas/core/internals/construction.py”, line 986, in _validate_or_indexify_columns
    raise AssertionError(
AssertionError: 6 columns passed, passed data had 4 columns
</pre>

which occurs because the largest identified consensus program consists of four individual programs from a total of six independent cNMF runs. Replacing `self.num_results` with the size of the largest cluster solves the issue.
