### PR TITLE
Update build_consensus_reference.py to fix Issue #20

### DIFF
--- a/src/starcat/build_consensus_reference.py
+++ b/src/starcat/build_consensus_reference.py
@@ -297,8 +297,8 @@ class BuildConsensusReference():
                 clus_dict_all[gep_num] = [gep]     
         
         # Relabel GEPs and order by cNMF result source
-        clus_df = pd.DataFrame.from_dict(clus_dict_all, orient='index', 
-                                         columns = ['GEP%d' % x for x in range(1, self.num_results+1)])
+        clus_df = pd.DataFrame.from_dict(clus_dict_all, orient='index')
+        
         result_names = sorted(clus_df.unstack().dropna().apply(lambda x: x.split(':')[0]).unique())
         
         clus_df_clean = pd.DataFrame(index=clus_df.index, columns=result_names)


### PR DESCRIPTION
Description: This PR fixes the issue where an error is raised when the maximum size of clusters generated when running cluster_cnmf_results is less than the total number of datasets/paths passed to the BuildConsensusReference class.

Changes: Removed column name designation, "columns=[...]", from pd.DataFrame.from_dict() call in lines 300-301. This makes it so that the number of columns is just set by the maximum cluster size. These column names are never referenced again and the output of this function is not returned directly by the function so this change does not have any downstream effect.

Related Issue: Fixes #20